### PR TITLE
chore: document multi-issue reference convention & widen PR-title checks (#10)

### DIFF
--- a/.github/LABELS.md
+++ b/.github/LABELS.md
@@ -30,9 +30,13 @@ type(scope?)!?: description (#issue)
 - `description` **starts with a lowercase letter** and has **no trailing period**.
   Preserve acronyms and proper nouns: `OpenCTI`, `OpenAEV`, `XTM One`, `OpenGRC`,
   `STIX`, `LLM`, `Docker`, `Redis`.
-- `(#issue)` is a **required reference on pull request titles** (the PR title
-  becomes the squash-merge commit, so the reference lands on `master`/`main`).
-  Issue titles omit it (the issue *is* the reference).
+- `(#issue)` is a **required reference on pull request titles**. Use a single
+  parenthesised group: one issue `(#1234)`, or several comma-separated
+  `(#1234, #1235, #1236)`. When the PR is squash-merged, GitHub **automatically
+  appends the PR number**, so the commit on `master`/`main` reads
+  `… (#1234, #1235) (#5678)` — the trailing `(#5678)` is the PR id added by GitHub,
+  never typed in the title. Issue titles omit the reference (the issue *is* the
+  reference).
 
 Enforcement is preventive and lives at the organization (enterprise) level; the
 [`FiligranHQ/filigran-ci-tools` `pr-title-check`](https://github.com/FiligranHQ/filigran-ci-tools/tree/main/actions/pr-title-check)

--- a/.github/workflows/validate-pr-title.yml
+++ b/.github/workflows/validate-pr-title.yml
@@ -25,7 +25,7 @@ jobs:
           ALLOWED_TYPES='feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert'
 
           # Required format: type(scope?)!?: description (#123)
-          PATTERN="^(${ALLOWED_TYPES})(\([a-z0-9]+([_-][a-z0-9]+)*(\/[a-z0-9]+([_-][a-z0-9]+)*)*\))?!?: [a-z0-9].* \(#[0-9]+\)$"
+          PATTERN="^(${ALLOWED_TYPES})(\([a-z0-9]+([_-][a-z0-9]+)*(\/[a-z0-9]+([_-][a-z0-9]+)*)*\))?!?: [a-z0-9].* \(#[0-9]+(, ?#[0-9]+)*\)$"
 
           if [[ "${TITLE}" =~ ${PATTERN} ]]; then
             echo "PR title is valid."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ in [`.github/LABELS.md`](.github/LABELS.md). In short:
   instead (e.g. `fix(backend): ...`).
 
 * **GitHub reference** — Pull request titles **must** end with the related issue
-  reference, e.g. `(#1234)` (the PR title becomes the squash-merge commit). Every
+  reference, e.g. `(#1234)`, or `(#1234, #1235)` for multiple issues. GitHub automatically appends the PR number to the squash-merge commit, e.g. `… (#1234, #1235) (#5678)`. Every
   pull request must be linked to an issue. Enforcement is preventive and applied
   at the organization level; **Renovate** pull requests are exempt.
 


### PR DESCRIPTION
## Summary

Documents the multi-issue reference convention `(#XX, #YY, #ZZ)` (GitHub appends the PR id `(#AA)` to the squash commit automatically) and widens the PR-title check regex to accept multiple comma-separated issues.

Closes #10